### PR TITLE
added benchmark test

### DIFF
--- a/NN/FFNN1L.py
+++ b/NN/FFNN1L.py
@@ -39,7 +39,7 @@ class FFNN1L:
 
     def softmax_choice(self, x):
         x_softmax = np.exp(x)/sum(np.exp(x))
-        return np.choice(len(x), p=x_softmax)
+        return np.random.choice(len(x), p=x_softmax)
 
     def init_weights(self):
         return np.random.randn(self.nneurs, self.state_size)

--- a/NN/RNN1L.py
+++ b/NN/RNN1L.py
@@ -40,7 +40,7 @@ class RNN1L:
 
     def softmax_choice(self, x):
         x_softmax = np.exp(x)/sum(np.exp(x))
-        return np.choice(len(x), p=x_softmax)
+        return np.random.choice(len(x), p=x_softmax)
 
 
     def init_weights(self):

--- a/scripts/benchmark_example.py
+++ b/scripts/benchmark_example.py
@@ -3,4 +3,4 @@ import Benchmark
 
 #Benchmark.benchmark_classic_control_envs(N_gen=2000)
 #Benchmark.benchmark_envs(['CartPole-v0', 'LunarLander-v2'], N_gen=300)
-Benchmark.benchmark_envs(['CartPole-v0'], N_dist=10, N_gen=100, output_fn='softmax')
+Benchmark.benchmark_envs(['CartPole-v0'], N_dist=30, N_gen=3000)

--- a/src/Agent.py
+++ b/src/Agent.py
@@ -33,13 +33,16 @@ class Agent:
             # should be implemented.
             self.action_scale = env.action_space.high.max()
 
+        # Lets the user override it if they supplied one; otherwise uses default value.
+        output_fn = kwargs.get('output_fn', output_fn)
+
         # Select the NN class to use.
         NN_types_dict = {
             'RNN' : RNN1L,
             'FFNN' : FFNN1L
         }
 
-        NN_type = kwargs.get('NN', 'RNN')
+        NN_type = kwargs.get('NN', 'FFNN')
         assert NN_type in NN_types_dict.keys(), 'Must supply a valid NN type!'
         self.NN = NN_types_dict[NN_type](self.ninputs, self.nactions, output_fn=output_fn)
 

--- a/src/Benchmark.py
+++ b/src/Benchmark.py
@@ -11,7 +11,7 @@ Will eventually be made into a class that will handle all the benchmarking
 details. For now, just holds benchmark_envs.
 '''
 
-
+@path_utils.timer
 def benchmark_envs(env_list, **kwargs):
 
     '''

--- a/src/Evolve.py
+++ b/src/Evolve.py
@@ -86,19 +86,20 @@ class Evolve:
                 print(f'New best score {best_score:.3f} in generation {gen}')
                 best_weights = self.agent.get_weight_matrix()
 
-                # If it achieved a new best score, test for self.N_eval_trials episode average score.
-                # If self.N_eval_trials ep mean score is >= self.solved_avg_reward, it's considered solved.
-                eval_trials = []
-                for _ in range(self.N_eval_trials):
-                    eval_trials.append(self.run_episode())
+                if mean_score > 0.8*self.solved_avg_reward:
+                    # If it achieved a new best score, test for self.N_eval_trials episode average score.
+                    # If self.N_eval_trials ep mean score is >= self.solved_avg_reward, it's considered solved.
+                    eval_trials = []
+                    for _ in range(self.N_eval_trials):
+                        eval_trials.append(self.run_episode())
 
-                eval_mean = np.mean(eval_trials)
-                if eval_mean >= self.solved_avg_reward:
-                    print(f'\t==> Solved! {self.N_eval_trials} ep mean score = {eval_mean:.2f} in gen {gen}')
-                    solved = True
-                    solve_gen = gen
-                else:
-                    print(f'\t==> Unsolved. {self.N_eval_trials} ep mean score = {eval_mean:.2f} in gen {gen}')
+                    eval_mean = np.mean(eval_trials)
+                    if eval_mean >= self.solved_avg_reward:
+                        print(f'\t==> Solved! {self.N_eval_trials} ep mean score = {eval_mean:.2f} in gen {gen}')
+                        solved = True
+                        solve_gen = gen
+                    else:
+                        print(f'\t==> Unsolved. {self.N_eval_trials} ep mean score = {eval_mean:.2f} in gen {gen}')
 
             all_scores.append(mean_score)
             best_scores.append(best_score)
@@ -190,7 +191,6 @@ class Evolve:
             plt.show()
 
 
-
     def show_best_episode(self, weights):
 
         '''
@@ -201,7 +201,6 @@ class Evolve:
 
         self.agent.set_weight_matrix(weights)
         ep_score = self.run_episode(show_ep=True, record_ep=False)
-
 
 
     def record_best_episode(self, weights):


### PR DESCRIPTION
Made it so instead of testing with 100 trials when `mean_score > best_score`, still update the best score then, but only test with 100 trials this way:

```
            if (best_score is None) or (mean_score > best_score):
                best_score = mean_score
                print(f'New best score {best_score:.3f} in generation {gen}')
                best_weights = self.agent.get_weight_matrix()

                if mean_score > 0.8*self.solved_avg_reward:
                    # If it achieved a new best score, test for self.N_eval_trials episode average score.
                    # If self.N_eval_trials ep mean score is >= self.solved_avg_reward, it's considered solved.
                    eval_trials = []
                    for _ in range(self.N_eval_trials):
                        eval_trials.append(self.run_episode())

                    eval_mean = np.mean(eval_trials)
```

So now it's not testing on scores that are the current best, but low. It speeds up execution maybe 10x or more.

Also added a decorator timer to the benchmark function, and fixed a bug with `np.random.choice`.